### PR TITLE
Add whole outputs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ wheels/
 *.egg
 
 # Outputs
-outputs/*.json
+outputs/**
+outputs/
 
 # IDE specific files
 .idea/


### PR DESCRIPTION
I'd like to ignore local outputs from being tracked on git. Don't think the json files for output visibility should be in the git repo. Let me know if we think otherwise. If we want to keep them, I can figure out a better path for them.

<img width="960" alt="Screenshot 2025-01-10 at 9 47 07 AM" src="https://github.com/user-attachments/assets/0f45a36e-9c4d-45e0-89d0-8d274c41240b" />
